### PR TITLE
Add initial MCP scaffold with dummy tool and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-11-29
+### Added
+- Initial MCP scaffold with in-memory server, dummy tool, and CLI.
+- Testing infrastructure with pytest and coverage configuration.
+- Project metadata and development tooling configuration via `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # tigl-mcp
-An MCP for TiGL
+
+A lightweight scaffold for a Model Context Protocol (MCP) server focused on TiGL. The
+current implementation provides an in-memory tool registry, a dummy tool for smoke
+testing, and a small command-line interface.
+
+## Features
+
+- In-memory `MCPServer` for registering and dispatching tools
+- Pydantic-backed parameter validation via reusable tool definitions
+- Dummy tool to verify the server pipeline end to end
+- CLI for quick manual checks and catalog export
+- Pytest-based test suite with coverage reporting
+
+## Getting started
+
+Install the project in editable mode along with the development dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+```
+
+Run the test suite to verify the scaffold:
+
+```bash
+pytest
+```
+
+Inspect the available tools from the command line:
+
+```bash
+python -m tigl_mcp.cli --catalog
+```
+
+Running without flags executes the dummy tool and prints a JSON payload.
+
+## Contributing
+
+- Keep modules single-purpose and favor pure functions.
+- Use the provided formatting and linting configuration (`black`, `ruff`, `mypy`).
+- Add tests for new behavior and prefer clear Arrange-Act-Assert structure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tigl-mcp"
+version = "0.1.0"
+description = "Initial MCP scaffold for TiGL"
+authors = [{name = "TiGL Team"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.9.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "mypy>=1.11",
+  "ruff>=0.6.0",
+  "black>=24.8.0",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I", "B", "UP", "ANN", "C4", "D"]
+ignore = ["D203", "D213"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_ignores = true
+warn_unused_configs = true
+strict = true
+mypy_path = "src"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=tigl_mcp --cov-report=term-missing"

--- a/src/tigl_mcp/__init__.py
+++ b/src/tigl_mcp/__init__.py
@@ -1,0 +1,6 @@
+"""tigl_mcp package initialization."""
+
+from tigl_mcp.server import MCPServer
+from tigl_mcp.tools import ToolDefinition, register_dummy_tool
+
+__all__ = ["MCPServer", "ToolDefinition", "register_dummy_tool"]

--- a/src/tigl_mcp/cli.py
+++ b/src/tigl_mcp/cli.py
@@ -1,0 +1,45 @@
+"""Command-line interface for the TiGL MCP scaffold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+from tigl_mcp.server import MCPServer
+from tigl_mcp.tools import register_dummy_tool
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the CLI."""
+
+    parser = argparse.ArgumentParser(description="Run the TiGL MCP scaffold.")
+    parser.add_argument(
+        "--catalog",
+        action="store_true",
+        help="Print the available tool catalog as JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the CLI."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    server = MCPServer()
+    server.register_tool(register_dummy_tool())
+
+    if args.catalog:
+        catalog = server.to_catalog()
+        print(json.dumps(catalog, indent=2))
+        return 0
+
+    result = server.run_tool("dummy")
+    print(result.to_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tigl_mcp/server.py
+++ b/src/tigl_mcp/server.py
@@ -1,0 +1,113 @@
+"""Minimal MCP server scaffolding.
+
+This module contains the foundation needed to bootstrap a Model Context Protocol (MCP)
+server for TiGL. The current implementation focuses on predictable registration and
+execution behavior while leaving network plumbing for future iterations.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
+
+from tigl_mcp.tools import ToolDefinition
+
+
+@dataclass
+class ToolResult:
+    """Result returned by tool execution.
+
+    Attributes:
+        name: Name of the tool that produced the result.
+        payload: Structured payload returned by the tool.
+    """
+
+    name: str
+    payload: Dict[str, Any]
+
+    def to_json(self) -> str:
+        """Serialize the result to JSON.
+
+        Returns:
+            JSON representation of the tool result.
+        """
+
+        return json.dumps({"name": self.name, "payload": self.payload})
+
+
+class MCPServer:
+    """In-memory registry and dispatcher for MCP tools.
+
+    The server tracks registered tools and provides a simple dispatch mechanism. It is
+    intentionally free of transport details to keep the early scaffold focused and
+    testable.
+    """
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, ToolDefinition] = {}
+
+    def register_tool(self, tool: ToolDefinition) -> None:
+        """Register a tool with the server.
+
+        Args:
+            tool: Tool definition to register.
+
+        Raises:
+            ValueError: If a tool with the same name is already registered.
+        """
+
+        if tool.name in self._tools:
+            raise ValueError(f"Tool '{tool.name}' is already registered")
+        self._tools[tool.name] = tool
+
+    def available_tools(self) -> List[str]:
+        """List the names of registered tools.
+
+        Returns:
+            Sorted list of tool names.
+        """
+
+        return sorted(self._tools)
+
+    def run_tool(self, name: str, *, parameters: Dict[str, Any] | None = None) -> ToolResult:
+        """Execute a registered tool.
+
+        Args:
+            name: Name of the registered tool to execute.
+            parameters: Optional parameters for the tool.
+
+        Raises:
+            KeyError: If the tool name is not registered.
+            ValueError: If parameter validation fails.
+
+        Returns:
+            ToolResult containing the tool name and structured payload.
+        """
+
+        if name not in self._tools:
+            raise KeyError(f"Tool '{name}' is not registered")
+
+        tool = self._tools[name]
+        validated_params = tool.validate(parameters or {})
+        payload = tool.handler(validated_params)
+        return ToolResult(name=name, payload=payload)
+
+    def register_tools(self, *tools: ToolDefinition) -> None:
+        """Register multiple tools at once.
+
+        Args:
+            *tools: Collection of tool definitions to register.
+        """
+
+        for tool in tools:
+            self.register_tool(tool)
+
+    def to_catalog(self) -> Dict[str, Dict[str, Any]]:
+        """Produce a catalog for discovery.
+
+        Returns:
+            Mapping of tool names to their metadata.
+        """
+
+        return {name: tool.metadata() for name, tool in self._tools.items()}

--- a/src/tigl_mcp/tools.py
+++ b/src/tigl_mcp/tools.py
@@ -1,0 +1,85 @@
+"""Tool definitions for the TiGL MCP scaffold."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+
+class ToolParameters(BaseModel):
+    """Base parameters schema for MCP tools."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@dataclass
+class ToolDefinition:
+    """Description of a tool that can be registered with the server.
+
+    Attributes:
+        name: Unique name of the tool.
+        description: Human-readable description of the tool purpose.
+        parameters_model: Pydantic model used to validate input parameters.
+        handler: Callable that executes the tool logic.
+    """
+
+    name: str
+    description: str
+    parameters_model: type[ToolParameters]
+    handler: Callable[[Dict[str, Any]], Dict[str, Any]]
+
+    def validate(self, parameters: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate and coerce incoming tool parameters.
+
+        Args:
+            parameters: Input parameters provided for the tool.
+
+        Raises:
+            ValueError: If parameter validation fails.
+
+        Returns:
+            Validated parameter dictionary.
+        """
+
+        try:
+            model = self.parameters_model(**parameters)
+        except ValidationError as error:
+            raise ValueError(f"Invalid parameters for tool '{self.name}'") from error
+        return model.model_dump()
+
+    def metadata(self) -> Dict[str, Any]:
+        """Return a discovery-friendly description of the tool."""
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "schema": self.parameters_model.model_json_schema(),
+        }
+
+
+def register_dummy_tool() -> ToolDefinition:
+    """Create a placeholder tool for early testing.
+
+    Returns:
+        ToolDefinition wired to the dummy handler.
+    """
+
+    class DummyParameters(ToolParameters):
+        """No-op parameter schema for the dummy tool."""
+
+    def handler(_: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a static response for smoke testing."""
+
+        return {
+            "status": "ok",
+            "message": "Dummy tool executed successfully",
+        }
+
+    return ToolDefinition(
+        name="dummy",
+        description="Placeholder tool used while building out MCP plumbing.",
+        parameters_model=DummyParameters,
+        handler=handler,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,42 @@
+"""CLI behavior smoke tests."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from tigl_mcp import cli
+
+
+def test_cli_outputs_dummy_tool(monkeypatch, capsys) -> None:  # type: ignore[annotation-unchecked]
+    """Running the CLI without flags should execute the dummy tool."""
+
+    # Arrange
+    argv: List[str] = []
+
+    # Act
+    exit_code = cli.main(argv)
+
+    # Assert
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["name"] == "dummy"
+    assert parsed["payload"]["status"] == "ok"
+
+
+def test_cli_catalog_flag(monkeypatch, capsys) -> None:  # type: ignore[annotation-unchecked]
+    """Catalog flag should print tool discovery metadata."""
+
+    # Arrange
+    argv: List[str] = ["--catalog"]
+
+    # Act
+    exit_code = cli.main(argv)
+
+    # Assert
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    catalog = json.loads(captured.out)
+    assert "dummy" in catalog
+    assert catalog["dummy"]["description"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,78 @@
+"""Tests for the MCP server scaffold."""
+
+from __future__ import annotations
+
+import json
+import pytest
+
+from tigl_mcp.server import MCPServer
+from tigl_mcp.tools import register_dummy_tool
+
+
+class TestMCPServer:
+    """Behavioral coverage for MCPServer."""
+
+    def test_register_and_list_tools(self) -> None:
+        """Registers a tool and ensures it appears in the catalog."""
+
+        # Arrange
+        server = MCPServer()
+        dummy = register_dummy_tool()
+
+        # Act
+        server.register_tool(dummy)
+
+        # Assert
+        assert server.available_tools() == ["dummy"]
+        catalog = server.to_catalog()
+        assert "dummy" in catalog
+        assert catalog["dummy"]["description"] == dummy.description
+
+    def test_prevents_duplicate_tool_names(self) -> None:
+        """Duplicate tool registrations raise a ValueError."""
+
+        # Arrange
+        server = MCPServer()
+        dummy = register_dummy_tool()
+        server.register_tool(dummy)
+
+        # Act / Assert
+        with pytest.raises(ValueError):
+            server.register_tool(dummy)
+
+    def test_runs_registered_tool(self) -> None:
+        """Executing a registered tool returns its payload."""
+
+        # Arrange
+        server = MCPServer()
+        server.register_tool(register_dummy_tool())
+
+        # Act
+        result = server.run_tool("dummy")
+
+        # Assert
+        assert result.name == "dummy"
+        assert result.payload["status"] == "ok"
+        assert json.loads(result.to_json())["payload"]["message"]
+
+    def test_running_unknown_tool_errors(self) -> None:
+        """Unknown tool invocations raise a KeyError."""
+
+        # Arrange
+        server = MCPServer()
+
+        # Act / Assert
+        with pytest.raises(KeyError):
+            server.run_tool("missing")
+
+    def test_rejects_invalid_parameters(self) -> None:
+        """Invalid parameters are surfaced as validation errors."""
+
+        # Arrange
+        server = MCPServer()
+        dummy = register_dummy_tool()
+        server.register_tool(dummy)
+
+        # Act / Assert
+        with pytest.raises(ValueError):
+            server.run_tool("dummy", parameters={"unexpected": "value"})


### PR DESCRIPTION
## Summary
- add initial MCP server scaffold with dummy tool registration and CLI entry point
- configure project metadata, tooling, and documentation for development
- add pytest-based tests covering server behavior and CLI outputs

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b38b4ac688325b7d1b43cbbbaea56)