### PR TITLE
Integrate FastMCP server and protocol tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ All notable changes to this project will be documented in this file.
 - Initial MCP scaffold with in-memory server, dummy tool, and CLI.
 - Testing infrastructure with pytest and coverage configuration.
 - Project metadata and development tooling configuration via `pyproject.toml`.
+
+## [0.2.0] - 2025-03-01
+### Added
+- FastMCP integration for the TiGL toolset with stdio and HTTP transports.
+- Adapter layer that registers existing tools with FastMCP while preserving session management.
+- End-to-end FastMCP protocol tests that exercise tool discovery and error propagation.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ registry used for validation and catalog export.
 
 ## Features
 
-- In-memory `MCPServer` for registering and dispatching tools
+- FastMCP-powered MCP server with stdio and HTTP transports
 - Pydantic-backed parameter validation via reusable tool definitions
 - TiGL/CPACS-aware tool implementations backed by a reusable `SessionManager`
 - JSON-serializable tool definitions for the full geometry workflow
@@ -48,6 +48,15 @@ python -m tigl_mcp_server --catalog
 ```
 
 The catalog is derived from pydantic schemas, and every tool returns structured JSON.
+
+Start the FastMCP server over stdio or HTTP transports:
+
+```bash
+python -m tigl_mcp_server --transport stdio
+
+# or expose websocket/SSE discovery endpoints over HTTP
+python -m tigl_mcp_server --transport http --host 127.0.0.1 --port 8000
+```
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "pydantic>=2.9.0",
+  "fastmcp~=2.13.1",
 ]
 
 [project.optional-dependencies]

--- a/src/tigl_mcp_server/fastmcp_adapter.py
+++ b/src/tigl_mcp_server/fastmcp_adapter.py
@@ -1,0 +1,54 @@
+"""Adapters for exposing TiGL MCP tools via FastMCP."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.tools import Tool
+from fastmcp.tools.tool import ToolResult
+
+from tigl_mcp.tools import ToolDefinition
+from tigl_mcp_server.session_manager import SessionManager
+from tigl_mcp_server.tools import build_tools
+
+
+class ToolDefinitionAdapter(Tool):
+    """Expose a :class:`ToolDefinition` as a FastMCP tool."""
+
+    def __init__(self, definition: ToolDefinition) -> None:
+        """Create a FastMCP tool wrapper for the provided definition."""
+        super().__init__(
+            name=definition.name,
+            description=definition.description,
+            parameters=definition.parameters_model.model_json_schema(),
+            output_schema=definition.output_schema,
+            tags=set(),
+        )
+        self._definition = definition
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        """Validate arguments and delegate to the wrapped handler."""
+        validated_arguments = self._definition.validate(arguments)
+        payload = self._definition.handler(validated_arguments)
+        return ToolResult(structured_content=payload)
+
+
+def to_fastmcp_tools(tool_definitions: Sequence[ToolDefinition]) -> list[Tool]:
+    """Convert legacy tool definitions into FastMCP-compatible tools."""
+    return [ToolDefinitionAdapter(definition) for definition in tool_definitions]
+
+
+def build_fastmcp_app(
+    session_manager: SessionManager,
+) -> tuple[FastMCP, list[ToolDefinition]]:
+    """Create a FastMCP server instance with all TiGL tools registered."""
+    app = FastMCP(
+        name="tigl-mcp-server",
+        instructions=("CPACS/TiGL utilities exposed over the Model Context Protocol."),
+    )
+    tool_definitions = build_tools(session_manager)
+    for tool in to_fastmcp_tools(tool_definitions):
+        app.add_tool(tool)
+    return app, tool_definitions

--- a/src/tigl_mcp_server/main.py
+++ b/src/tigl_mcp_server/main.py
@@ -1,28 +1,75 @@
-"""Entry point for the TiGL MCP server tool registry."""
+"""Entry point for the TiGL MCP FastMCP server."""
 
 from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Sequence
+from typing import Any
 
-from tigl_mcp.server import MCPServer
+from tigl_mcp_server.fastmcp_adapter import build_fastmcp_app
 from tigl_mcp_server.session_manager import session_manager
-from tigl_mcp_server.tools import build_tools
 
 
-def main() -> None:
-    """Register tools and print a JSON catalog."""
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the FastMCP server CLI."""
     parser = argparse.ArgumentParser(description="TiGL MCP server")
     parser.add_argument("--catalog", action="store_true", help="Print the tool catalog")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "http", "sse", "streamable-http"),
+        default="stdio",
+        help=(
+            "Transport for serving MCP (stdio for CLI integration, HTTP for "
+            "websocket/SSE endpoints)."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host to bind for HTTP-compatible transports (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind for HTTP-compatible transports (default: 8000)",
+    )
+    parser.add_argument(
+        "--path",
+        help=(
+            "Path to mount the HTTP endpoint (defaults to FastMCP's protocol-specific"
+            " path)."
+        ),
+    )
+    return parser
 
-    server = MCPServer()
-    server.register_tools(*build_tools(session_manager))
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Register tools and either print the catalog or start the server."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    app, tool_definitions = build_fastmcp_app(session_manager)
+
     if args.catalog:
-        print(json.dumps(server.to_catalog(), indent=2))
-    else:
-        print(json.dumps({"tools": server.available_tools()}))
+        print(
+            json.dumps(
+                {tool.name: tool.metadata() for tool in tool_definitions}, indent=2
+            )
+        )
+        return 0
+
+    transport_kwargs: dict[str, Any] = {}
+    if args.transport in {"http", "sse", "streamable-http"}:
+        transport_kwargs["host"] = args.host
+        transport_kwargs["port"] = args.port
+        if args.path is not None:
+            transport_kwargs["path"] = args.path
+
+    app.run(transport=args.transport, **transport_kwargs)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def sample_cpacs_xml() -> str:
+    """Provide a small CPACS-like XML document for testing."""
+    return """
+    <cpacs>
+        <header>
+            <creator>Unit Test</creator>
+            <description>Sample CPACS content</description>
+        </header>
+        <vehicles>
+            <aircraft>
+                <model>
+                    <wings>
+                        <wing uid=\"W1\" name=\"MainWing\"
+                             span=\"30.0\" area=\"80.0\" symmetry=\"x-z\" />
+                    </wings>
+                    <fuselages>
+                        <fuselage uid=\"F1\" name=\"Fuse\" length=\"25.0\" />
+                    </fuselages>
+                </model>
+            </aircraft>
+        </vehicles>
+    </cpacs>
+    """

--- a/tests/test_fastmcp_server_integration.py
+++ b/tests/test_fastmcp_server_integration.py
@@ -1,0 +1,52 @@
+"""End-to-end coverage for the FastMCP server wrapper."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.client import Client
+
+from tigl_mcp_server.fastmcp_adapter import build_fastmcp_app
+from tigl_mcp_server.session_manager import SessionManager
+
+
+@pytest.mark.anyio()
+async def test_fastmcp_server_supports_tool_discovery(sample_cpacs_xml: str) -> None:
+    """The FastMCP server exposes the TiGL toolset via the official protocol."""
+    app, _ = build_fastmcp_app(SessionManager())
+
+    async with Client(app) as client:
+        tools = await client.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "open_cpacs" in tool_names
+        assert "get_configuration_summary" in tool_names
+
+        open_result = await client.call_tool(
+            "open_cpacs", {"source_type": "xml_string", "source": sample_cpacs_xml}
+        )
+        session_id = open_result.data["session_id"]
+
+        summary = await client.call_tool(
+            "get_configuration_summary", {"session_id": session_id}
+        )
+        assert summary.data["wings"][0]["uid"] == "W1"
+        assert summary.data["fuselages"][0]["uid"] == "F1"
+
+        close_result = await client.call_tool("close_cpacs", {"session_id": session_id})
+        assert close_result.data["success"] is True
+
+
+@pytest.mark.anyio()
+async def test_fastmcp_propagates_structured_errors() -> None:
+    """Errors raised by tool handlers surface through FastMCP client calls."""
+    app, _ = build_fastmcp_app(SessionManager())
+
+    async with Client(app) as client:
+        result = await client.call_tool(
+            "get_configuration_summary",
+            {"session_id": "invalid"},
+            raise_on_error=False,
+        )
+
+    assert result.is_error is True
+    assert "Unknown session_id" in result.content[0].text

--- a/tests/test_tigl_mcp_server.py
+++ b/tests/test_tigl_mcp_server.py
@@ -11,32 +11,6 @@ from tigl_mcp_server.tools import build_tools
 from tigl_mcp_server.tools.parameters import set_high_level_parameters_tool
 
 
-@pytest.fixture()
-def sample_cpacs_xml() -> str:
-    """Provide a small CPACS-like XML document for testing."""
-    return """
-    <cpacs>
-        <header>
-            <creator>Unit Test</creator>
-            <description>Sample CPACS content</description>
-        </header>
-        <vehicles>
-            <aircraft>
-                <model>
-                    <wings>
-                        <wing uid="W1" name="MainWing"
-                             span="30.0" area="80.0" symmetry="x-z" />
-                    </wings>
-                    <fuselages>
-                        <fuselage uid="F1" name="Fuse" length="25.0" />
-                    </fuselages>
-                </model>
-            </aircraft>
-        </vehicles>
-    </cpacs>
-    """
-
-
 def _tool_by_name(tools: list[ToolDefinition], name: str) -> ToolDefinition:
     """Locate a tool by name in the provided collection."""
     for tool in tools:


### PR DESCRIPTION
## Summary
- add a FastMCP adapter that registers TiGL tool definitions and expose transport options via the server CLI
- document the new FastMCP-powered server and update dependencies and changelog
- add end-to-end FastMCP protocol tests using shared CPACS fixtures

## Testing
- python -m black .
- python -m ruff check .
- python -m mypy --strict .
- PYTHONPATH=src python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b44df544c8325ae1e38fe1e701863)