### PR TITLE
Remove catalog CLI flags now that FastMCP handles discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A lightweight scaffold for a Model Context Protocol (MCP) server focused on TiGL. The
 project now includes a standalone `tigl_mcp_server` package that exposes TiGL/CPACS
-geometry through JSON-schema-described tools, alongside the original minimal MCP
-registry used for validation and catalog export.
+geometry through JSON-schema-described tools.
 
 ## Features
 
@@ -12,8 +11,7 @@ registry used for validation and catalog export.
 - TiGL/CPACS-aware tool implementations backed by a reusable `SessionManager`
 - JSON-serializable tool definitions for the full geometry workflow
 - Dummy tool to verify the legacy MCP pipeline end to end
-- CLI for quick manual checks and catalog export (`python -m tigl_mcp`)
-- Server catalog CLI for the new toolset (`python -m tigl_mcp_server --catalog`)
+- CLI for quick manual checks (`python -m tigl_mcp`)
 - Pytest-based test suite with coverage reporting
 
 ## Getting started
@@ -33,29 +31,21 @@ Run the test suite to verify the scaffold:
 pytest
 ```
 
-Inspect the available tools from the command line:
+Run the legacy dummy tool for quick smoke testing:
 
 ```bash
-python -m tigl_mcp.cli --catalog
+python -m tigl_mcp.cli
 ```
 
-Running without flags executes the dummy tool and prints a JSON payload.
-
-Inspect the TiGL MCP server tool catalog:
-
-```bash
-python -m tigl_mcp_server --catalog
-```
-
-The catalog is derived from pydantic schemas, and every tool returns structured JSON.
+The output is a structured JSON document from the dummy handler.
 
 Start the FastMCP server over stdio or HTTP transports:
 
 ```bash
-python -m tigl_mcp_server --transport stdio
+tigl-mcp-server --transport stdio
 
 # or expose websocket/SSE discovery endpoints over HTTP
-python -m tigl_mcp_server --transport http --host 127.0.0.1 --port 8000
+tigl-mcp-server --transport http --host 127.0.0.1 --port 8000 --path /mcp
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ tigl = [
   "tixi3",
 ]
 
+[project.scripts]
+tigl-mcp = "tigl_mcp.cli:main"
+tigl-mcp-server = "tigl_mcp_server.main:main"
+
 [tool.black]
 line-length = 88
 target-version = ["py311"]

--- a/src/tigl_mcp/cli.py
+++ b/src/tigl_mcp/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 
 from tigl_mcp.server import MCPServer
 from tigl_mcp.tools import register_dummy_tool
@@ -11,27 +10,16 @@ from tigl_mcp.tools import register_dummy_tool
 
 def build_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the CLI."""
-    parser = argparse.ArgumentParser(description="Run the TiGL MCP scaffold.")
-    parser.add_argument(
-        "--catalog",
-        action="store_true",
-        help="Print the available tool catalog as JSON.",
-    )
-    return parser
+    return argparse.ArgumentParser(description="Run the TiGL MCP scaffold.")
 
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the CLI."""
     parser = build_parser()
-    args = parser.parse_args(argv)
+    parser.parse_args(argv)
 
     server = MCPServer()
     server.register_tool(register_dummy_tool())
-
-    if args.catalog:
-        catalog = server.to_catalog()
-        print(json.dumps(catalog, indent=2))
-        return 0
 
     result = server.run_tool("dummy")
     print(result.to_json())

--- a/src/tigl_mcp_server/main.py
+++ b/src/tigl_mcp_server/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 from collections.abc import Sequence
 from typing import Any
 
@@ -14,7 +13,6 @@ from tigl_mcp_server.session_manager import session_manager
 def build_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the FastMCP server CLI."""
     parser = argparse.ArgumentParser(description="TiGL MCP server")
-    parser.add_argument("--catalog", action="store_true", help="Print the tool catalog")
     parser.add_argument(
         "--transport",
         choices=("stdio", "http", "sse", "streamable-http"),
@@ -46,19 +44,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Register tools and either print the catalog or start the server."""
+    """Register tools and start the FastMCP server."""
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    app, tool_definitions = build_fastmcp_app(session_manager)
-
-    if args.catalog:
-        print(
-            json.dumps(
-                {tool.name: tool.metadata() for tool in tool_definitions}, indent=2
-            )
-        )
-        return 0
+    app, _tool_definitions = build_fastmcp_app(session_manager)
 
     transport_kwargs: dict[str, Any] = {}
     if args.transport in {"http", "sse", "streamable-http"}:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import json
 
-from pytest import CaptureFixture, MonkeyPatch
+from pytest import CaptureFixture
 
 from tigl_mcp import cli
 
 
-def test_cli_outputs_dummy_tool(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
-) -> None:
+def test_cli_outputs_dummy_tool(capsys: CaptureFixture[str]) -> None:
     """Running the CLI without flags should execute the dummy tool."""
     # Arrange
     argv: list[str] = []
@@ -25,21 +23,3 @@ def test_cli_outputs_dummy_tool(
     parsed = json.loads(captured.out)
     assert parsed["name"] == "dummy"
     assert parsed["payload"]["status"] == "ok"
-
-
-def test_cli_catalog_flag(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
-) -> None:
-    """Catalog flag should print tool discovery metadata."""
-    # Arrange
-    argv: list[str] = ["--catalog"]
-
-    # Act
-    exit_code = cli.main(argv)
-
-    # Assert
-    assert exit_code == 0
-    captured = capsys.readouterr()
-    catalog = json.loads(captured.out)
-    assert "dummy" in catalog
-    assert catalog["dummy"]["description"]

--- a/tests/test_fastmcp_server_cli.py
+++ b/tests/test_fastmcp_server_cli.py
@@ -1,0 +1,50 @@
+"""CLI-level coverage for the FastMCP server wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from tigl_mcp_server import main as server_main
+
+
+class _DummyApp:
+    """Shim FastMCP app to capture run invocations without network I/O."""
+
+    def __init__(self) -> None:
+        self.run_calls: list[dict[str, object]] = []
+
+    def add_tool(self, _: object) -> None:  # pragma: no cover - not used directly
+        return
+
+    def run(
+        self, *, transport: str, **kwargs: object
+    ) -> None:  # pragma: no cover - exercised via main
+        self.run_calls.append({"transport": transport, **kwargs})
+
+
+def test_main_runs_fastmcp_with_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() delegates to FastMCP.run with the provided transport settings."""
+    dummy_app = _DummyApp()
+    monkeypatch.setattr(
+        server_main,
+        "build_fastmcp_app",
+        lambda _session_manager: (dummy_app, []),
+    )
+
+    exit_code = server_main.main(
+        [
+            "--transport",
+            "http",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8080",
+            "--path",
+            "/mcp",
+        ]
+    )
+
+    assert exit_code == 0
+    assert dummy_app.run_calls == [
+        {"transport": "http", "host": "127.0.0.1", "port": 8080, "path": "/mcp"}
+    ]


### PR DESCRIPTION
## Summary
- drop catalog flag handling from both legacy and FastMCP CLIs
- simplify documentation to focus on smoke testing and transport configuration
- update CLI tests to reflect removal of catalog export

## Testing
- ruff check .
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b481ec234832594d8836b332b1212)